### PR TITLE
Auth tweaks

### DIFF
--- a/api/users.js
+++ b/api/users.js
@@ -39,7 +39,7 @@ router.get('/:id', requireAuthentication, async (req, res, next) => {
     }
     // If Student, fetch the list of Courses they are enrolled in
     if (user.role == 'student') {
-      user.courses = {};    
+      user.courses = {};
     }
 
     res.status(201).send(user);
@@ -94,16 +94,9 @@ router.post('/login', async (req, res, next) => {
 
       if (auth) {
         // Fetch additional data about user to include in token
-        //const user = await getUserDetailsByEmail(req.body.email);
-
-        // Static data for testing
-        var user = {};
-        user.id = "17";
-        user.email = "user@example.com";
-        user.role = 'admin';
-        user.name = "Admin User";
-        user.password = "adminPassword";
-
+        const user = await getUserDetailsByEmail(req.body.email);
+        delete user.password;
+         
         const token = generateAuthToken(user);
 
         res.status(200).send({ token: token });

--- a/api/users.js
+++ b/api/users.js
@@ -28,8 +28,20 @@ router.get('/:id', requireAuthentication, async (req, res, next) => {
 
   try {
 
-
     const user = await getUserDetailsById(req.params.id);
+
+    // Remove sensitive information
+    delete user.password;
+
+    // If Instructor, fetch the list of Courses they teach
+    if (user.role == 'instructor') {
+      user.courses = {};
+    }
+    // If Student, fetch the list of Courses they are enrolled in
+    if (user.role == 'student') {
+      user.courses = {};    
+    }
+
     res.status(201).send(user);
 
   } catch (err) {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -24,59 +24,54 @@ exports.generateAuthToken = (user) => {
   return token;
 };
 
-// exports.requireAuthentication = async (req, res, next) => {
-  //   const authHeader = req.get('Authorization') || '';
-  //   const authHeaderParts = authHeader.split(' ');
-  //   const token = authHeaderParts[0] === 'Bearer' ? authHeaderParts[1] : null;
-  //
-  //   try {
-    //     // Ensure that a token was provided
-    //     if (!token) {
-      //       throw CustomError("No token provided.", 401);
-      //     }
-      //
-      //     const payload = jwt.verify(token, secretKey);
-      //
-      //     // Dump token data back into req for later use
-      //     req.user = payload;
-      //
-      //     next();
-      //   } catch (err) {
-        //
-        //     // Allow POST /users with or without a token to support
-        //     // anonymous as well as admin registration
-        //     if (req.method == "POST" && req.baseUrl == "/users") {
-          //       next();
-          //     } else {
-            //       // Bypass auth for testing
-            //       //next();
-            //       next(new CustomError("Invalid authentication token", 403))
-            //     }
-            //   }
-            // };
-// exports.requireAdmin = (req, res, next) => {
-              //   if (req.user.role == 'admin') {
-                //     next();
-                //   } else {
-                  //     // Bypass auth for testing
-                  //     //next();
-                  //     next(new CustomError("Not authorized.", 403))
-                  //   }
-                  // }
-/*
- * Middleware function to verify JWT token and pass values back into req.user
- */
+exports.requireAuthentication = async (req, res, next) => {
+  const authHeader = req.get('Authorization') || '';
+  const authHeaderParts = authHeader.split(' ');
+  const token = authHeaderParts[0] === 'Bearer' ? authHeaderParts[1] : null;
 
-exports.requireAuthentication = async (req, res, next) =>{
-  next();
+  try {
+    // Ensure that a token was provided
+    if (!token) {
+      throw CustomError("No token provided.", 401);
+    }
+
+    const payload = jwt.verify(token, secretKey);
+
+    // Dump token data back into req for later use
+    req.user = payload;
+
+    next();
+  } catch (err) {
+
+    // Allow POST /users with or without a token to support
+    // anonymous as well as admin registration
+    if (req.method == "POST" && req.baseUrl == "/users") {
+      next();
+    } else {
+        // Bypass auth for testing
+        //next();
+        next(new CustomError("Invalid authentication token", 403))
+    }
+  }
 }
+
+
+
+
 /*
  * Require the requestor to have admin role
  */
-
-exports.requireAdmin = (req, res, next) =>{
-  next();
+exports.requireAdmin = (req, res, next) => {
+  if (req.user.role == 'admin') {
+    next();
+  } else {
+      // Bypass auth for testing
+      //next();
+      next(new CustomError("Not authorized.", 403));
+  }
 }
+
+
 /*
  * Require the requestor to have instructor role AND match the instructorId
  * of the requested course.
@@ -89,7 +84,7 @@ exports.requireCourseInstructorOrAdmin = async (req, res, next) => {
   } else {
     // Bypass auth for testing
     //next();
-    next(new CustomError("Not authorized.", 403))
+    next(new CustomError("Not authorized.", 403));
   }
 }
 
@@ -105,6 +100,6 @@ exports.requireEnrolledStudent = async (req, res, next) => {
   } else {
     // Bypass auth for testing
     //next();
-    next(new CustomError("Not authorized.", 403))
+    next(new CustomError("Not authorized.", 403));
   }
 }

--- a/models/user.js
+++ b/models/user.js
@@ -42,22 +42,9 @@ exports.insertNewUser = async (user) => {
   const collection = await db.collection('users');
   const passwordHash = await bcrypt.hash(userToInsert.password, 8);
   userToInsert.password = passwordHash;
-  const result = await collection.insertOne(userToInsert).insertedId;
-  return result;
+  const result = await collection.insertOne(userToInsert);
+  return result.insertedId;
 }
-
-
-/*
- * Authenticate a User against the DB.
- someone else can work on this
- */
-exports.authenticateUser = async (user) => {
-  console.log(" == authenticateUser: user", user);
-  const checkUser = await getUserDetailsById(user.id);
-  const authenticated = user && await bcrypt.compare(user.password, checkUser.password)
-  return authenticated;
-}
-
 
 /*
  * Fetch details about a User by Id
@@ -65,25 +52,39 @@ exports.authenticateUser = async (user) => {
 exports.getUserDetailsById = async (id) => {
   const db = getDBReference();
   var user;
-  user = await db.collection('users').findOne({ _id: new mongodb.ObjectId(id)});
+  user = await db.collection('users').findOne({ _id: new ObjectId(id)});
   console.log(" == getUserDetailsById id", id);
   delete user.password;
   return user;
 }
 
+/*
+ * Authenticate a User against the DB.
+ someone else can work on this
+ */
+exports.authenticateUser = async (user) => {
+  console.log(" == authenticateUser: user", user);
+  const checkUser = await getUserDetailsByEmail(user.email);
+  const authenticated = user && await bcrypt.compare(user.password, checkUser.password)
+  return authenticated;
+}
+
 
 /*
  * Fetch details about a User by Email address
+ * Use a second like for exports because we need to call this function
+ * locally as well.
  */
-exports.getUserDetailsByEmail = async (email) => {
+getUserDetailsByEmail = async (email) => {
   const db = getDBReference();
 
-  // becasue the varialbe name and the object name are the same,
+  // becasue the variable name and the object name are the same,
   //we can just leave it as { email, } thnx es6
 
    var user;
    user = await db.collection('users').findOne({email})
    console.log(" == getUserDetailsByEmail email", email,"\nUser: ",user);
-   delete user.password;
+
   return user;
 }
+exports.getUserDetailsByEmail = getUserDetailsByEmail;


### PR DESCRIPTION
Merged in PR 5 and tested /user/* routes.

- Fixed a few small typo and function call issues
- Students can register anonymously
- Admins can register admin and instructor users
- All user roles can log in and JWT tokens issued
- Only admin or owners can request /users/{id}
- Removed admin placeholder in POST /login and replaced with actual user data